### PR TITLE
Before convert, use do_shortcode

### DIFF
--- a/src/Base/UPL/Enrichment/Services/EnrichmentProductResolver.php
+++ b/src/Base/UPL/Enrichment/Services/EnrichmentProductResolver.php
@@ -119,7 +119,7 @@ class EnrichmentProductResolver
                 if (empty($translation[$key])) {
                     continue;
                 }
-                $translation[$key] = $converter->convert($translation[$key]);
+                $translation[$key] = $converter->convert(do_shortcode($translation[$key]));
             }
 
             return $translation;


### PR DESCRIPTION
Ik heb hem voor u even zo gedaan. We moeten morgen even overleggen of bijv. de `span` tag wel gebruikt mag worden in de Markup. Ik lees op diverse plekken dat het wel zou moeten kunnen: https://daringfireball.net/projects/markdown/syntax#span